### PR TITLE
Add unittests to project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-and-run-unittests:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +21,9 @@ jobs:
 
       - name: build
         run: make build
+
+      - name: unittests
+        run: make test
 
       - name: upload compile_commands.json
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /tests/
 /.DS_Store
+/.ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,17 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# install gtest
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        v1.17.0
+)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
 add_library(${PROJECT_NAME}_objs OBJECT
     src/utils/parser.hpp
     src/utils/parser.cpp
@@ -15,9 +26,19 @@ add_library(${PROJECT_NAME}_objs OBJECT
     src/langs.hpp
 )
 
-# Цель для сборки
+# main program
 add_executable(${PROJECT_NAME} src/stress-test-runner.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_objs)
+
+# unittests
+add_executable(${PROJECT_NAME}_unittest
+	unittests/test-compiler-factory.cpp
+  unittests/test-language-mapper.cpp
+  unittests/test-parser.cpp
+)
+target_link_libraries(${PROJECT_NAME}_unittest PRIVATE ${PROJECT_NAME}_objs GTest::gtest_main)
+include(GoogleTest)
+gtest_discover_tests(${PROJECT_NAME}_unittest)
 
 # Прописать output в папку build/
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ build:
 	cmake --build $(BUILD_DIR)
 	@mkdir -p tests
 
+# run unittests
+.PHONY: test
+test: build
+	$(BUILD_DIR)/stress_testing_unittest
+
 # basic run (with standard checker)
 .PHONY: start-stress
 start-stress: build

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ src/*-runner
 
 - **CMake** ≥ 3.15  
 - **make**  
-- **clang++** (with C++20)
+- **clang** (with C++20)
 - **python3** (if you want to test **py** solutions)
 
 #### Build

--- a/unittests/test-compiler-factory.cpp
+++ b/unittests/test-compiler-factory.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include "../src/langs.hpp"
+
+TEST(TestCompilerFactory, TestCppPath) {
+    std::string path_to_file = "src/cpp-runner/generator.cpp";
+    auto compiler_ptr = CompilerFactory::FromPath(path_to_file);
+    auto& compiler = *compiler_ptr;
+    EXPECT_EQ(typeid(compiler), typeid(CppCompiler));
+}
+
+TEST(TestCompilerFactory, TestPyPath) {
+    std::string path_to_file = "src/py-runner/generator.py";
+    auto compiler_ptr = CompilerFactory::FromPath(path_to_file);
+    auto& compiler = *compiler_ptr;
+    EXPECT_EQ(typeid(compiler), typeid(PyCompiler));
+}
+
+TEST(TestCompilerFactory, TestBadPath) {
+    std::string path_to_file = "dummy.c";
+    EXPECT_ANY_THROW(CompilerFactory::FromPath(path_to_file));
+}
+

--- a/unittests/test-language-mapper.cpp
+++ b/unittests/test-language-mapper.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include "../src/langs.hpp"
+
+TEST(TestLanguageMapper, TestCppExtension) {
+    std::string ext = ".cpp";
+    auto lang_mapper = LanguageMapper();
+    EXPECT_EQ(lang_mapper.FromExtension(ext), Language::Cxx);
+}
+
+TEST(TestLanguageMapper, TestPyExtension) {
+    std::string ext = ".py";
+    auto lang_mapper = LanguageMapper();
+    EXPECT_EQ(lang_mapper.FromExtension(ext), Language::Python);
+}
+
+TEST(TestLanguageMapper, TestWrongExtension) {
+    std::string ext = ".js";
+    auto lang_mapper = LanguageMapper();
+    EXPECT_THROW(lang_mapper.FromExtension(ext), std::out_of_range);
+}
+

--- a/unittests/test-parser.cpp
+++ b/unittests/test-parser.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include "../src/utils/parser.hpp"
+
+TEST(TestGetExtension, TestSimpleExtension) {
+  std::string path = "/foo/bar.txt";
+  EXPECT_EQ(Parser::GetExtension(path), ".txt");
+}
+
+TEST(TestGetExtension, TestEmptyExtension) {
+  std::string path = "/foo/bar";
+  EXPECT_EQ(Parser::GetExtension(path), "");
+}
+
+TEST(TestGetExtension, TestHardExtension) {
+  std::string path = "/foo/../dummy/bar.cpp";
+  EXPECT_EQ(Parser::GetExtension(path), ".cpp");
+}
+
+TEST(TestGetExtension, TestRelativePathExtension) {
+  std::string path = "../dummy/bar.py";
+  EXPECT_EQ(Parser::GetExtension(path), ".py");
+}


### PR DESCRIPTION
Add unittests to project:
Now it is testing LanguageMapper, Parser and CompilerFactory.
This tests can be very usefull if you add new lang support and check old functionality
Also add unittest checking in Ci github